### PR TITLE
Enable drill-down to test case details

### DIFF
--- a/src/testSuites/detailedView/TestSuiteDetails.css
+++ b/src/testSuites/detailedView/TestSuiteDetails.css
@@ -61,3 +61,11 @@
 .test-suite-details-container ul li button {
     margin-left: 10px;
 }
+
+.clickable-row {
+    cursor: pointer;
+}
+
+.clickable-row:hover {
+    background-color: #f1f1f1;
+}

--- a/src/testSuites/detailedView/TestSuiteDetails.js
+++ b/src/testSuites/detailedView/TestSuiteDetails.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import './TestSuiteDetails.css';
 import { link } from "../../ngrock";
 
@@ -10,6 +10,7 @@ const TestSuiteDetails = () => {
     const [searchQuery, setSearchQuery] = useState('');
 
     const { search } = useLocation();
+    const navigate = useNavigate();
     const id = new URLSearchParams(search).get('id');
     const apiUrlDetails = `${link}/test-suite?id=${id}`.replace(/([^:]\/)\/+/g, "$1");
 
@@ -39,6 +40,10 @@ const TestSuiteDetails = () => {
             .then(data => setAllTestCases(data))
             .catch(error => console.error('Error fetching all test cases:', error));
     }, []);
+
+    const handleRowClick = (id) => {
+        navigate(`/testcases/${id}`);
+    };
 
     const handleDeleteTestCase = async (suiteId, caseId) => {
         try {
@@ -138,12 +143,21 @@ const TestSuiteDetails = () => {
                 </thead>
                 <tbody>
                     {testSuite.test_cases.map(testCase => (
-                        <tr key={testCase.id}>
+                        <tr
+                            key={testCase.id}
+                            onClick={() => !editMode && handleRowClick(testCase.id)}
+                            className={!editMode ? 'clickable-row' : ''}
+                        >
                             <td>{testCase.id}</td>
                             <td>{testCase.test.name}</td>
                             {editMode && (
                                 <td>
-                                    <button onClick={() => handleDeleteTestCase(testSuite.id, testCase.id)}>
+                                    <button
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleDeleteTestCase(testSuite.id, testCase.id);
+                                        }}
+                                    >
                                         Delete
                                     </button>
                                 </td>


### PR DESCRIPTION
## Summary
- allow clicking on test cases in a suite to view details
- style clickable rows in suite details

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npx eslint .` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68431925b594832594d678eda14a6ebe